### PR TITLE
WIP that breaks test [not to be merged]

### DIFF
--- a/R/roxygen-examples-add-remove.R
+++ b/R/roxygen-examples-add-remove.R
@@ -3,10 +3,8 @@
 #' @param roxygen Roxygen code examples that contains a dont* segment only.
 #' @keywords internal
 remove_dont_mask <- function(roxygen) {
-  potential_pos <- c(3L, length(roxygen) - 1L)
-  is_line_break_at_potential_pos <- which(roxygen[potential_pos] == "\n")
   mask <- c(
-    1L, 2L, length(roxygen), potential_pos[is_line_break_at_potential_pos]
+    1L, 2L, if (roxygen[3] == "\n") 3L, last(which(roxygen == "}"))
   ) %>% sort()
   list(
     code = roxygen[-mask], mask = paste(roxygen[seq2(1, 2)], collapse = "")

--- a/R/roxygen-examples-parse.R
+++ b/R/roxygen-examples-parse.R
@@ -32,10 +32,11 @@ post_parse_roxygen <- function(raw) {
   special <- substr(raw, 1, 1) == "%"
   len <- nchar(raw)
   newline_after <- substr(raw, len, len) == "\n"
-  must_instert_linebreak_after <- which(
-    (special & !newline_after) |
-      (raw == "}" & (!(lead(substr(raw, 1, 1)) %in% c(",", "}", ")"))))
-  )
+  # must_instert_linebreak_after <- which(
+  #   (special & !newline_after) |
+  #     (raw == "}" & (!(lead(substr(raw, 1, 1)) %in% c(",", "}", ")"))))
+  # )
+  must_instert_linebreak_after <- integer(0)
   split <- reduce(must_instert_linebreak_after +
                     seq(0L, length(must_instert_linebreak_after) - 1L),
                   append, values = "\n", .init = raw

--- a/R/roxygen-examples.R
+++ b/R/roxygen-examples.R
@@ -35,7 +35,6 @@ style_roxygen_code_example <- function(example, transformers) {
 #' @importFrom purrr map2 flatten_chr
 #' @keywords internal
 style_roxygen_code_example_segment <- function(one_dont, transformers) {
-  one_dont <- remove_blank_lines(one_dont)
   if (length(one_dont) < 1L) return(character())
   dont_seqs <- find_dont_seqs(one_dont)
   split_segments <- split_roxygen_segments(one_dont, unlist(dont_seqs))
@@ -68,7 +67,6 @@ style_roxygen_example_snippet <- function(code_snippet,
     mask <- decomposed$mask
   }
   code_snippet <- post_parse_roxygen(code_snippet) %>%
-    paste0(collapse = "\n") %>%
     parse_transform_serialize_r(transformers)
 
   if (is_dont) {

--- a/tests/testthat/roxygen-examples-complete/13-empty-lines-in.R
+++ b/tests/testthat/roxygen-examples-complete/13-empty-lines-in.R
@@ -1,0 +1,48 @@
+
+#' Create a style guide
+#'
+#' @param reindention A list of parameters for regex re-indention, most
+#'   conveniently constructed using [specify_reindention()].
+#' @examples
+#' # empty
+#'
+#'
+#' # two
+#'
+#'
+#'
+#'
+#' # more
+#' a <- 3
+#' # a comment
+#' \dontrun{
+#' x
+#'
+#' y # hi
+#'
+#' # more
+#'
+#' a <- 3
+#' }
+#' @importFrom purrr compact
+#' @export
+create_style_guide <- function(initialize = default_style_guide_attributes,
+                               line_break = NULL,
+                               space = NULL,
+                               token = NULL,
+                               indention = NULL,
+                               use_raw_indention = FALSE,
+                               reindention = tidyverse_reindention()) {
+  lst(
+    # transformer functions
+    initialize = lst(initialize),
+    line_break,
+    space,
+    token,
+    indention,
+    # transformer options
+    use_raw_indention,
+    reindention
+  ) %>%
+    map(compact)
+}

--- a/tests/testthat/roxygen-examples-complete/13-empty-lines-in_tree
+++ b/tests/testthat/roxygen-examples-complete/13-empty-lines-in_tree
@@ -1,0 +1,119 @@
+ROOT (token: short_text [lag_newlines/spaces] {pos_id})             
+ ¦--COMMENT: #' Cr [0/0] {1}                                        
+ ¦--COMMENT: #' [1/0] {2}                                           
+ ¦--COMMENT: #' @p [1/0] {3}                                        
+ ¦--COMMENT: #'    [1/0] {4}                                        
+ ¦--COMMENT: #' @e [1/0] {5}                                        
+ ¦--COMMENT: #' #  [1/0] {6}                                        
+ ¦--COMMENT: #' [1/0] {7}                                           
+ ¦--COMMENT: #' [1/0] {8}                                           
+ ¦--COMMENT: #' #  [1/0] {9}                                        
+ ¦--COMMENT: #' [1/0] {10}                                          
+ ¦--COMMENT: #' [1/0] {11}                                          
+ ¦--COMMENT: #' [1/0] {12}                                          
+ ¦--COMMENT: #' [1/0] {13}                                          
+ ¦--COMMENT: #' #  [1/0] {14}                                       
+ ¦--COMMENT: #' a  [1/0] {15}                                       
+ ¦--COMMENT: #' #  [1/0] {16}                                       
+ ¦--COMMENT: #' \d [1/0] {17}                                      
+ ¦--COMMENT: #' x [1/0] {18}                                        
+ ¦--COMMENT: #' [1/0] {19}                                          
+ ¦--COMMENT: #' y  [1/0] {20}                                       
+ ¦--COMMENT: #' [1/0] {21}                                          
+ ¦--COMMENT: #' #  [1/0] {22}                                       
+ ¦--COMMENT: #' [1/0] {23}                                          
+ ¦--COMMENT: #' a  [1/0] {24}                                       
+ ¦--COMMENT: #' } [1/0] {25}                                        
+ ¦--COMMENT: #' @i [1/0] {26}                                       
+ ¦--COMMENT: #' @e [1/0] {27}                                       
+ °--expr:  [1/0] {28}                                               
+     ¦--expr:  [0/1] {30}                                           
+     ¦   °--SYMBOL: creat [0/0] {29}                                
+     ¦--LEFT_ASSIGN: <- [0/1] {31}                                  
+     °--expr:  [0/0] {32}                                           
+         ¦--FUNCTION: funct [0/0] {33}                              
+         ¦--'(': ( [0/0] {34}                                       
+         ¦--SYMBOL_FORMALS: initi [0/1] {35}                        
+         ¦--EQ_FORMALS: = [0/1] {36}                                
+         ¦--expr:  [0/0] {38}                                       
+         ¦   °--SYMBOL: defau [0/0] {37}                            
+         ¦--',': , [0/31] {39}                                      
+         ¦--SYMBOL_FORMALS: line_ [1/1] {40}                        
+         ¦--EQ_FORMALS: = [0/1] {41}                                
+         ¦--expr:  [0/0] {43}                                       
+         ¦   °--NULL_CONST: NULL [0/0] {42}                         
+         ¦--',': , [0/31] {44}                                      
+         ¦--SYMBOL_FORMALS: space [1/1] {45}                        
+         ¦--EQ_FORMALS: = [0/1] {46}                                
+         ¦--expr:  [0/0] {48}                                       
+         ¦   °--NULL_CONST: NULL [0/0] {47}                         
+         ¦--',': , [0/31] {49}                                      
+         ¦--SYMBOL_FORMALS: token [1/1] {50}                        
+         ¦--EQ_FORMALS: = [0/1] {51}                                
+         ¦--expr:  [0/0] {53}                                       
+         ¦   °--NULL_CONST: NULL [0/0] {52}                         
+         ¦--',': , [0/31] {54}                                      
+         ¦--SYMBOL_FORMALS: inden [1/1] {55}                        
+         ¦--EQ_FORMALS: = [0/1] {56}                                
+         ¦--expr:  [0/0] {58}                                       
+         ¦   °--NULL_CONST: NULL [0/0] {57}                         
+         ¦--',': , [0/31] {59}                                      
+         ¦--SYMBOL_FORMALS: use_r [1/1] {60}                        
+         ¦--EQ_FORMALS: = [0/1] {61}                                
+         ¦--expr:  [0/0] {63}                                       
+         ¦   °--NUM_CONST: FALSE [0/0] {62}                         
+         ¦--',': , [0/31] {64}                                      
+         ¦--SYMBOL_FORMALS: reind [1/1] {65}                        
+         ¦--EQ_FORMALS: = [0/1] {66}                                
+         ¦--expr:  [0/0] {67}                                       
+         ¦   ¦--expr:  [0/0] {69}                                   
+         ¦   ¦   °--SYMBOL_FUNCTION_CALL: tidyv [0/0] {68}          
+         ¦   ¦--'(': ( [0/0] {70}                                   
+         ¦   °--')': ) [0/0] {71}                                   
+         ¦--')': ) [0/1] {72}                                       
+         °--expr:  [0/0] {73}                                       
+             ¦--'{': { [0/2] {74}                                   
+             ¦--expr:  [1/0] {75}                                   
+             ¦   ¦--expr:  [0/1] {76}                               
+             ¦   ¦   ¦--expr:  [0/0] {78}                           
+             ¦   ¦   ¦   °--SYMBOL_FUNCTION_CALL: lst [0/0] {77}    
+             ¦   ¦   ¦--'(': ( [0/4] {79}                           
+             ¦   ¦   ¦--COMMENT: # tra [1/4] {80}                   
+             ¦   ¦   ¦--SYMBOL_SUB: initi [1/1] {81}                
+             ¦   ¦   ¦--EQ_SUB: = [0/1] {82}                        
+             ¦   ¦   ¦--expr:  [0/0] {83}                           
+             ¦   ¦   ¦   ¦--expr:  [0/0] {85}                       
+             ¦   ¦   ¦   ¦   °--SYMBOL_FUNCTION_CALL: lst [0/0] {84}
+             ¦   ¦   ¦   ¦--'(': ( [0/0] {86}                       
+             ¦   ¦   ¦   ¦--expr:  [0/0] {88}                       
+             ¦   ¦   ¦   ¦   °--SYMBOL: initi [0/0] {87}            
+             ¦   ¦   ¦   °--')': ) [0/0] {89}                       
+             ¦   ¦   ¦--',': , [0/4] {90}                           
+             ¦   ¦   ¦--expr:  [1/0] {92}                           
+             ¦   ¦   ¦   °--SYMBOL: line_ [0/0] {91}                
+             ¦   ¦   ¦--',': , [0/4] {93}                           
+             ¦   ¦   ¦--expr:  [1/0] {95}                           
+             ¦   ¦   ¦   °--SYMBOL: space [0/0] {94}                
+             ¦   ¦   ¦--',': , [0/4] {96}                           
+             ¦   ¦   ¦--expr:  [1/0] {98}                           
+             ¦   ¦   ¦   °--SYMBOL: token [0/0] {97}                
+             ¦   ¦   ¦--',': , [0/4] {99}                           
+             ¦   ¦   ¦--expr:  [1/0] {101}                          
+             ¦   ¦   ¦   °--SYMBOL: inden [0/0] {100}               
+             ¦   ¦   ¦--',': , [0/4] {102}                          
+             ¦   ¦   ¦--COMMENT: # tra [1/4] {103}                  
+             ¦   ¦   ¦--expr:  [1/0] {105}                          
+             ¦   ¦   ¦   °--SYMBOL: use_r [0/0] {104}               
+             ¦   ¦   ¦--',': , [0/4] {106}                          
+             ¦   ¦   ¦--expr:  [1/2] {108}                          
+             ¦   ¦   ¦   °--SYMBOL: reind [0/0] {107}               
+             ¦   ¦   °--')': ) [1/0] {109}                          
+             ¦   ¦--SPECIAL-PIPE: %>% [0/4] {110}                   
+             ¦   °--expr:  [1/0] {111}                              
+             ¦       ¦--expr:  [0/0] {113}                          
+             ¦       ¦   °--SYMBOL_FUNCTION_CALL: map [0/0] {112}   
+             ¦       ¦--'(': ( [0/0] {114}                          
+             ¦       ¦--expr:  [0/0] {116}                          
+             ¦       ¦   °--SYMBOL: compa [0/0] {115}               
+             ¦       °--')': ) [0/0] {117}                          
+             °--'}': } [1/0] {118}                                  

--- a/tests/testthat/roxygen-examples-complete/13-empty-lines-out.R
+++ b/tests/testthat/roxygen-examples-complete/13-empty-lines-out.R
@@ -1,0 +1,51 @@
+
+#' Create a style guide
+#'
+#' @param reindention A list of parameters for regex re-indention, most
+#'   conveniently constructed using [specify_reindention()].
+#' @examples
+#' 
+#' # empty
+#' 
+#' 
+#' # two
+#' 
+#' 
+#' 
+#' 
+#' # more
+#' a <- 3
+#' # a comment
+#' @examples
+#' \dontrun{
+#' x
+#' 
+#' y # hi
+#' 
+#' # more
+#' 
+#' a <- 3
+#' }
+#' 
+#' @importFrom purrr compact
+#' @export
+create_style_guide <- function(initialize = default_style_guide_attributes,
+                               line_break = NULL,
+                               space = NULL,
+                               token = NULL,
+                               indention = NULL,
+                               use_raw_indention = FALSE,
+                               reindention = tidyverse_reindention()) {
+  lst(
+    # transformer functions
+    initialize = lst(initialize),
+    line_break,
+    space,
+    token,
+    indention,
+    # transformer options
+    use_raw_indention,
+    reindention
+  ) %>%
+    map(compact)
+}


### PR DESCRIPTION
Attempt to use clear definitions for code line:
* until immediately before transofmriong: \n characterizes line break,

* map the previous definition to the styler definition. One line is one element. Can't simply paste0(...) %>% strplit("\n", fixed = TRUE) I think.