### PR TITLE
Review: Alignment vignette

### DIFF
--- a/vignettes/detect-alignment.Rmd
+++ b/vignettes/detect-alignment.Rmd
@@ -21,7 +21,8 @@ call(
 
 ```
 
-Until styler 1.1.1.9002 (with `strict = TRUE`, e.g. as in `styler::style_file(..., strict = TRUE)`), this was formatted as follows:
+Until styler 1.1.1.9002 (with `strict = TRUE`, e.g. as in
+`styler::style_file(..., strict = TRUE)`), this was formatted as follows:
 
 ```{r}
 call(
@@ -31,16 +32,22 @@ call(
 
 ```
 
-because no alignment detection was built in.^[With `strict = FALSE`, the spacing would have been kept, however, `strict = FALSE` has a number of other implications because it is in general less invasive. For example, it would not add braces and line breaks to "if (TRUE) return()".]
+because no alignment detection was built in.^[With `strict = FALSE`, the spacing
+would have been kept, however, `strict = FALSE` has a number of other
+implications because it is in general less invasive. For example, it would not
+add braces and line breaks to "if (TRUE) return()".]
 
-styler >= 1.1.1.9003 detects aforementioned alignment for function calls. 
-This vignette describes how aligned code is defined in styler and gives some examples so users can format their aligned code to match the definition styler uses to ensure their code is not unintentionally reformatted.
+styler >= 1.1.1.9003 detects aforementioned alignment for function calls. This
+vignette describes how aligned code is defined in styler and gives some examples
+so users can format their aligned code to match the definition styler uses to
+ensure their code is not unintentionally reformatted.
 
-An important definition used in the remainder is the one of a **column**. 
-All arguments of a function call that have the same position but are placed on different lines form a column. 
-The below call shows a call with two columns and two rows. 
-Columns separate arguments of the function call, so the separator is the comma. 
-The first row is named because all arguments are named, the second is unnamed:
+An important definition used in the remainder is the one of a **column**. All
+arguments of a function call that have the same position but are placed on
+different lines form a column. The below call shows a call with two columns and
+two rows. Columns separate arguments of the function call, so the separator is
+the comma. The first row is named because all arguments are named, the second is
+unnamed:
 
 ```{r}
 call(
@@ -54,9 +61,11 @@ call(
 
 ### Non-technical definition
 
-Below, we try to explain in an intuitive way how your code should look like to be recognized as aligned.
+Below, we try to explain in an intuitive way how your code should look like to
+be recognized as aligned.
 
-**If all arguments in the first column are named**: Make commas match position vertically and right align everything between commas:
+**If all arguments in the first column are named**: Make commas match position
+vertically and right align everything between commas:
 
 ```{r}
 # all arguments of first column named -> must right align
@@ -78,12 +87,15 @@ fell(
 
 **If not all arguments of the first column are named:**^[In the below example,
 the first argument of the first column is named (`p = 2`). The second argument
-of the first column is not (`31`).] 
-Make **all except the first column's commas** match position 
+of the first column is not (`31`).] Make **all except the first column's
+commas** match position
 
-- vertically 
+- vertically
+
 - right align everything between the commas
+
 - except before the first comma on a line
+
 - give priority to correctly indent (i.e. left align):
 
 ```{r}
@@ -97,9 +109,10 @@ gell(
 ```
 
 By *align everything in between the commas*, we mean put zero space before a
-comma and at least one after. 
-Note that the arguments on the first line are ignored when detecting alignment, which is best shown when code is formatted such that no line breaks will be modified by _styler_.
-This applies if all names on the first line are unnamed and all subsequent are named:
+comma and at least one after. Note that the arguments on the first line are
+ignored when detecting alignment, which is best shown when code is formatted
+such that no line breaks will be modified by _styler_. This applies if all names
+on the first line are unnamed and all subsequent are named:
 
 ```{r}
 map(x, f, 
@@ -127,14 +140,16 @@ purrr::map(x, fun, # arguments on same line as opening brace are not considered
 
 ## Technical definition
 
-This section closely follows the implementation of the alignment detection and is mostly aimed at developers for understanding _styler_ internals.
+This section closely follows the implementation of the alignment detection and
+is mostly aimed at developers for understanding _styler_ internals.
 
 Function calls are aligned if **all** of the following conditions hold (for all
 but the very first line (i.e. `call(` below):
 
-* all rows in first column have the same number of lag spaces. 
-  This basically means that the indention is identical for all columns (except for the closing brace if it is on its own line). 
-  The below example has one column, because the maximal number of commas on one line is one.
+* all rows in first column have the same number of lag spaces. This basically
+  means that the indention is identical for all columns (except for the closing
+  brace if it is on its own line). The below example has one column, because the
+  maximal number of commas on one line is one.
 
 ```{r}
 # holds
@@ -150,7 +165,8 @@ call(
 )
 ```
 
-* spacing around comma (0 before, > 1 after, >= 0 after last column on line) and spacing around `=` (at least one before and after).
+* spacing around comma (0 before, > 1 after, >= 0 after last column on line) and
+  spacing around `=` (at least one before and after).
 
 ```{r}
 # holds
@@ -166,12 +182,18 @@ call(
 )
 ```
 
-* All commas from all columns are aligned. 
-  This means that for every column, all commas must be on the same positions as the commas from the other lines. If not all arguments are named in the first column, this column is not considered. 
-  The reason to exclude the first column is that, as in the example below, it is possible that some arguments are named while others are not. 
-  Then, it is not generally possible to keep the first rule (i.e. indention identical across lines). Also ensuring that the comma does not have any spaces before it and its alignment with other lines does not hold true. This is shown below with the line `f(x, y),`. 
-  For this reason, the requirements exclude the first column in such cases. 
-  The *holds* example shows that is is possible (but not required) for named arguments to also have the commas separating the first and second column aligned.
+* All commas from all columns are aligned. This means that for every column, all
+  commas must be on the same positions as the commas from the other lines. If
+  not all arguments are named in the first column, this column is not
+  considered. The reason to exclude the first column is that, as in the example
+  below, it is possible that some arguments are named while others are not.
+  Then, it is not generally possible to keep the first rule (i.e. indention
+  identical across lines). Also ensuring that the comma does not have any spaces
+  before it and its alignment with other lines does not hold true. This is shown
+  below with the line `f(x, y),`. For this reason, the requirements exclude the
+  first column in such cases. The *holds* example shows that is is possible (but
+  not required) for named arguments to also have the commas separating the first
+  and second column aligned.
 
 ```{r}
 # holds
@@ -190,7 +212,8 @@ call(
 )
 ```
 
-Note that the above definition does not check alignment of `=`, so _styler_ will treat the following as aligned:
+Note that the above definition does not check alignment of `=`, so _styler_ will
+treat the following as aligned:
 
 ```{r}
 rge(
@@ -206,3 +229,4 @@ not supported yet.
 ## Assignment
 
 not supported yet.
+

--- a/vignettes/detect-alignment.Rmd
+++ b/vignettes/detect-alignment.Rmd
@@ -21,8 +21,7 @@ call(
 
 ```
 
-Until styler 1.1.1.9002 (with `strict = TRUE`, e.g. as in
-`styler::style_file(..., strict = TRUE)`), this was formatted as follows:
+Until styler 1.1.1.9002 (with `strict = TRUE`, e.g. as in `styler::style_file(..., strict = TRUE)`), this was formatted as follows:
 
 ```{r}
 call(
@@ -32,22 +31,16 @@ call(
 
 ```
 
-because no alignment detection was built in.^[With `strict = FALSE`, the spacing
-would have been kept, however, `strict = FALSE` has a number of other
-implications because it is in general less invasive. For example, it would not
-add braces and line breaks to "if (TRUE) return()".]
+because no alignment detection was built in.^[With `strict = FALSE`, the spacing would have been kept, however, `strict = FALSE` has a number of other implications because it is in general less invasive. For example, it would not add braces and line breaks to "if (TRUE) return()".]
 
-styler >= 1.1.1.9003 detects aforementioned alignment for function calls. This
-vignette describes how aligned code is defined in styler and gives some examples
-so users can format their aligned code to match the definition styler uses to
-ensure their code is not unintentionally reformatted.
+styler >= 1.1.1.9003 detects aforementioned alignment for function calls. 
+This vignette describes how aligned code is defined in styler and gives some examples so users can format their aligned code to match the definition styler uses to ensure their code is not unintentionally reformatted.
 
-An important definition used in the remainder is the one of a **column**. All
-arguments of a function call that have the same position but are placed on
-different lines form a column. The below call shows a call with two columns and
-two rows. Columns separate arguments of the function call, so the separator is
-the comma. The first row is named because all arguments are named, the second is
-unnamed:
+An important definition used in the remainder is the one of a **column**. 
+All arguments of a function call that have the same position but are placed on different lines form a column. 
+The below call shows a call with two columns and two rows. 
+Columns separate arguments of the function call, so the separator is the comma. 
+The first row is named because all arguments are named, the second is unnamed:
 
 ```{r}
 call(
@@ -61,11 +54,9 @@ call(
 
 ### Non-technical definition
 
-Below, we try to explain in an intuitive way how your code should look like to
-be recognized as aligned.
+Below, we try to explain in an intuitive way how your code should look like to be recognized as aligned.
 
-**If all arguments in the first column are named**: Make commas match position
-vertically and right align everything between commas:
+**If all arguments in the first column are named**: Make commas match position vertically and right align everything between commas:
 
 ```{r}
 # all arguments of first column named -> must right align
@@ -86,10 +77,14 @@ fell(
 ```
 
 **If not all arguments of the first column are named:**^[In the below example,
-the first argument of the first column is named (`p = 2`), the second argument
-of the first column is not (`31`)] Make all but the first column's commas match
-position vertically and right align everything between the commas, except before
-the first comma on a line, give priority to correctly indent (i.e. left align):
+the first argument of the first column is named (`p = 2`). The second argument
+of the first column is not (`31`).] 
+Make **all except the first column's commas** match position 
+
+- vertically 
+- right align everything between the commas
+- except before the first comma on a line
+- give priority to correctly indent (i.e. left align):
 
 ```{r}
 # not all arguments of first column named, hence, only 
@@ -102,10 +97,9 @@ gell(
 ```
 
 By *align everything in between the commas*, we mean put zero space before a
-comma and at least one after. Note that the arguments on the first line are
-ignored when detecting alignment, which is best shown when code is formatted
-such that no line breaks will be modified by styler (which is the case if all
-names on the first line are unnamed and all subsequent are named), like here:
+comma and at least one after. 
+Note that the arguments on the first line are ignored when detecting alignment, which is best shown when code is formatted such that no line breaks will be modified by _styler_.
+This applies if all names on the first line are unnamed and all subsequent are named:
 
 ```{r}
 map(x, f, 
@@ -116,7 +110,7 @@ map(x, f,
 
 **Examples**
 
-These typical examples match styler's definition of alignment.
+These typical examples match _styler_'s definition of alignment.
 
 ```{r}
 tibble::tribble(
@@ -133,16 +127,14 @@ purrr::map(x, fun, # arguments on same line as opening brace are not considered
 
 ## Technical definition
 
-This section closely follows the implementation of the alignment detection and
-is mostly aimed at developers for understanding styler internals.
+This section closely follows the implementation of the alignment detection and is mostly aimed at developers for understanding _styler_ internals.
 
 Function calls are aligned if **all** of the following conditions hold (for all
 but the very first line (i.e. `call(` below):
 
-* all rows in first column has same number of lag spaces. This basically means
-  that the indention is identical for all columns (except for the closing brace
-  if it is on its own line). The below example has one column, because the
-  maximal number of commas on one line is one.
+* all rows in first column have the same number of lag spaces. 
+  This basically means that the indention is identical for all columns (except for the closing brace if it is on its own line). 
+  The below example has one column, because the maximal number of commas on one line is one.
 
 ```{r}
 # holds
@@ -158,8 +150,7 @@ call(
 )
 ```
 
-* spacing around comma (0 before, > 1 after, >= 0 after last column on line) and
-  spacing around `=` (at least one before and after).
+* spacing around comma (0 before, > 1 after, >= 0 after last column on line) and spacing around `=` (at least one before and after).
 
 ```{r}
 # holds
@@ -175,18 +166,12 @@ call(
 )
 ```
 
-* All commas from all columns are aligned. This means that for every column, all
-  commas must be on the same positions as the commas from the other lines. If
-  not all arguments are named in the first column, this column is not
-  considered. The reason to exclude the first column is that, as in the example
-  below, it is possible that some arguments are named while others are not.
-  Then, it is not generally possible to keep the first rule (i.e. indention
-  identical across lines) as well as ensuring that the comma does not have any
-  spaces before it and that the comma is aligned with the other lines. This is
-  shown below with the line `f(x, y),`. For this reason, the requirements
-  exclude the first column in such cases. The *holds* example shows that is is
-  possible (but not required) for named arguments to also have the commas
-  separating the first and second column aligned.
+* All commas from all columns are aligned. 
+  This means that for every column, all commas must be on the same positions as the commas from the other lines. If not all arguments are named in the first column, this column is not considered. 
+  The reason to exclude the first column is that, as in the example below, it is possible that some arguments are named while others are not. 
+  Then, it is not generally possible to keep the first rule (i.e. indention identical across lines). Also ensuring that the comma does not have any spaces before it and its alignment with other lines does not hold true. This is shown below with the line `f(x, y),`. 
+  For this reason, the requirements exclude the first column in such cases. 
+  The *holds* example shows that is is possible (but not required) for named arguments to also have the commas separating the first and second column aligned.
 
 ```{r}
 # holds
@@ -205,8 +190,7 @@ call(
 )
 ```
 
-Note that the above definition does not check alignment of `=`, so styler will
-treat the following as aligned:
+Note that the above definition does not check alignment of `=`, so _styler_ will treat the following as aligned:
 
 ```{r}
 rge(

--- a/vignettes/detect-alignment.Rmd
+++ b/vignettes/detect-alignment.Rmd
@@ -223,3 +223,5 @@ not supported yet.
 
 not supported yet.
 
+dummy
+

--- a/vignettes/detect-alignment.Rmd
+++ b/vignettes/detect-alignment.Rmd
@@ -206,6 +206,3 @@ not supported yet.
 ## Assignment
 
 not supported yet.
-
-dummy
-


### PR DESCRIPTION
As per https://github.com/r-lib/styler/issues/258#issuecomment-541457005

- Put each sentence on a new line (makes reviewing text a lot easier on GH)
- formatted pkg name as italics
- broke up some long sentences into smaller ones

Regarding your thought of a too complex wording:
I guess this is at some point unavoidable here. 
I would also not put too much energy into the vignette as the practical use case should be most descriptive and users who write aligned code usually do not really profit from it.

They will most likely try it out and see how _styler_ does.

---

Maybe it would be of interest to add a R6 example using a dictionary structure (I couldn't find one right away in the mlr repos right now).